### PR TITLE
Feature/edit and deactivate user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 **/**.db
 **/.DS_Store
 .DS_Store
+
+# DotSettings
+*.sln.DotSettings.user

--- a/PatientAnalytics/Blazor/Components/ConfirmationModal.razor
+++ b/PatientAnalytics/Blazor/Components/ConfirmationModal.razor
@@ -1,5 +1,4 @@
-﻿@using PatientAnalytics.Blazor.Models
-@inject IStringLocalizer<Localized> Localized
+﻿@inject IStringLocalizer<Localized> Localized
 
 @if (Alert is not null)
 {

--- a/PatientAnalytics/Blazor/Components/ConfirmationModal.razor
+++ b/PatientAnalytics/Blazor/Components/ConfirmationModal.razor
@@ -1,45 +1,24 @@
-﻿@inject IStringLocalizer<Localized> Localized
+﻿@using PatientAnalytics.Blazor.Models
+@inject IStringLocalizer<Localized> Localized
 
-<div class="modal @ModalClass">
-    <div class="modal-background"></div>
-    <div class="modal-card">
-        <header class="modal-card-head">
-            <p class="modal-card-title">@Title</p>
-            <button class="delete" aria-label="close" @onclick="Close"></button>
-        </header>
-        <footer class="modal-card-foot">
-            <button class="button is-danger mr-3" @onclick="OnConfirm">@ConfirmButtonText</button>
-            <button class="button" @onclick="Close">@CancelButtonText</button>
-        </footer>
+@if (Alert is not null)
+{
+    <div class="modal is-active">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">@Alert.Title</p>
+                <button class="delete" aria-label="close" @onclick="Alert.OnCancel"></button>
+            </header>
+            <footer class="modal-card-foot">
+                <button class="button is-danger mr-3" @onclick="Alert.OnConfirm">@Alert.ConfirmButtonText</button>
+                <button class="button" @onclick="Alert.OnCancel">@Alert.CancelButtonText</button>
+            </footer>
+        </div>
     </div>
-</div>
+}
 
 @code {
-    [Parameter, EditorRequired] 
-    public string Title { get; set; } = "";
-    [Parameter, EditorRequired]
-    public string ConfirmButtonText { get; set; } = "";
-    [Parameter, EditorRequired]
-    public string CancelButtonText { get; set; } = "";
     [Parameter]
-    public EventCallback OnConfirm { get; set; }
-    [Parameter]
-    public EventCallback OnCancel { get; set; }
-    [Parameter]
-    public bool IsVisible { get; set; }
-
-    private string ModalClass => IsVisible ? "is-active" : string.Empty;
-
-    protected override void OnParametersSet()
-    {
-        if (Title is null) throw new InvalidOperationException("The 'Title' parameter is required.");
-        if (ConfirmButtonText is null) throw new InvalidOperationException("The 'ConfirmButtonText' parameter is required.");
-        if (CancelButtonText is null) throw new InvalidOperationException("The 'CancelButtonText' parameter is required.");
-    }
-
-
-    private void Close()
-    {
-        OnCancel.InvokeAsync();
-    }
+    public Alert? Alert { private get; set; }
 }

--- a/PatientAnalytics/Blazor/Components/PersonDetailsDisplay.razor
+++ b/PatientAnalytics/Blazor/Components/PersonDetailsDisplay.razor
@@ -1,0 +1,31 @@
+@inject IStringLocalizer<Localized> Localized
+
+<section class="box">
+    <div class="container">
+        <h1 class="title">@Title</h1>
+        <h2 class="title is-4">
+            @string.Format(Localized["Format_FullName"], Person.FirstName, Person.LastName)
+        </h2>
+        <ContentWithLabel Label="@Localized["Label_Email"]">@Person.Email</ContentWithLabel>
+        <ContentWithLabel Label="@Localized["Label_Gender"]">@Person.Gender</ContentWithLabel>
+        <ContentWithLabel Label="@Localized["Label_DateOfBirth"]">
+            @Person.DateOfBirth.ToString(Localized["DateFormatting_Date"])
+        </ContentWithLabel>
+        <ContentWithLabel Label="@Localized["Label_Address"]">@Person.Address</ContentWithLabel>
+
+        <div class="divider"></div>
+
+        <ContentWithLabel Label="@Localized["Label_DateCreated"]">
+            @Person.DateCreated.ToString(Localized["DateFormatting_DateTime"])
+        </ContentWithLabel>
+        <ContentWithLabel Label="@Localized["Label_DateEdited"]">
+            @Person.DateEdited?.ToString(Localized["DateFormatting_DateTime"])
+        </ContentWithLabel>
+    </div>
+</section>
+
+@code {
+    [Parameter] public string Title { private get; set; } = null!;
+    
+    [Parameter] public Person Person { private get; set; } = null!;
+}

--- a/PatientAnalytics/Blazor/Components/UserEditAccountInfoModal.razor
+++ b/PatientAnalytics/Blazor/Components/UserEditAccountInfoModal.razor
@@ -1,0 +1,89 @@
+@inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
+@inject UserService UserService
+@inject IStringLocalizer<Localized> Localized
+
+@if (IsModalOpen)
+{
+    <div class="modal is-active">
+        <div class="modal-background"></div>
+        <div class="modal-card">
+            <header class="modal-card-head">
+                <p class="modal-card-title">@Localized["Button_UpdateUser"]</p>
+                <button class="delete" aria-label="close" @onclick="CloseModal"></button>
+            </header>
+            <section class="modal-card-body">
+                <EditForm method="post" Model="_payload" OnValidSubmit="HandleSubmit" Enhance>
+                    <DataAnnotationsValidator />
+                    <ValidationSummary class="text-danger" />
+                    <div class="field">
+                        <label class="label">@Localized["Label_Gender"]</label>
+                        <InputText class="input" placeholder=@Localized["Placeholder_Gender"] @bind-Value="_payload.Gender" />
+                        <ValidationMessage For="() => _payload.Gender" class="text-danger" />
+                    </div>
+                    <div class="field">
+                        <label class="label">@Localized["Label_First_Name"]</label>
+                        <InputText class="input" placeholder=@Localized["Placeholder_First_Name"] @bind-Value="_payload.FirstName" />
+                        <ValidationMessage For="() => _payload.FirstName" class="text-danger" />
+                    </div>
+                    <div class="field">
+                        <label class="label">@Localized["Label_Last_Name"]</label>
+                        <InputText class="input" placeholder=@Localized["Placeholder_Last_Name"] @bind-Value="_payload.LastName" />
+                        <ValidationMessage For="() => _payload.LastName" class="text-danger" />
+                    </div>
+                    <div class="field">
+                        <label class="label">@Localized["Label_Address"]</label>
+                        <InputText class="input" placeholder=@Localized["Placeholder_Address"] @bind-Value="_payload.Address" />
+                        <ValidationMessage For="() => _payload.Address" class="text-danger" />
+                    </div>
+                    <div class="field">
+                        <label class="label">@Localized["Label_DateOfBirth"]</label>
+                        <InputDate class="input" placeholder=@Localized["Placeholder_DateOfBirth"] @bind-Value="_payload.DateOfBirth" />
+                        <ValidationMessage For="() => _payload.DateOfBirth" class="text-danger" />
+                    </div>
+                    <button type="submit" class="button is-primary">@Localized["Button_Update"]</button>
+                    <p class="has-text-danger">@ErrorMessage</p>
+                </EditForm>
+            </section>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter] public bool IsModalOpen { private get; set; }
+    [Parameter] public EventCallback OnClose { private get; set; }
+    [Parameter] public EventCallback<User> OnUserEdited { private get; set; }
+    [Parameter] public User User { get; set; } = null!;
+
+    private UserAccountInfoPayload _payload = new();
+    private string ErrorMessage { get; set; } = string.Empty;
+    
+    protected override void OnInitialized()
+    {
+        _payload = UserAccountInfoPayload.CreatePayloadFromUser(User);
+    }
+
+    private async Task HandleSubmit()
+    {
+        var token = PatientAnalyticsAuthStateProvider.FetchCurrentUser().Token;
+        ErrorMessage = string.Empty;
+
+        try
+        {
+            var user = await UserService.EditUserAccountInfo(token, User.Id, _payload);
+            
+            await OnUserEdited.InvokeAsync(user);
+            
+            await OnClose.InvokeAsync();
+        }
+        catch (HttpStatusCodeException exception)
+        {
+            ErrorMessage = exception.Message;
+        }
+    }
+
+    private void CloseModal()
+    {
+        OnClose.InvokeAsync();
+        _payload = new UserAccountInfoPayload();
+    }
+}

--- a/PatientAnalytics/Blazor/Components/UsersTable.razor
+++ b/PatientAnalytics/Blazor/Components/UsersTable.razor
@@ -1,4 +1,5 @@
 @inject IStringLocalizer<Localized> Localized
+@inject NavigationManager NavigationManager
 
 <table class="table">
     <thead>
@@ -25,6 +26,11 @@
             <td>@string.Format(Localized["Format_FullName"], user.FirstName, user.LastName)</td>
             <td>@user.Gender</td>
             <td>@user.DateOfBirth.ToString(Localized["DateFormatting_Date"])</td>
+            <td>
+                <button onclick="@(() => NavigationManager.NavigateTo($"/user-management/users/{ user.Id }"))">
+                    View
+                </button>
+            </td>
         </tr>
     }
     </tbody>

--- a/PatientAnalytics/Blazor/Components/Wrappers/PatientDashboardWrapper.razor
+++ b/PatientAnalytics/Blazor/Components/Wrappers/PatientDashboardWrapper.razor
@@ -1,5 +1,4 @@
-﻿@using PatientAnalytics.Services.PatientMetrics
-@inject IStringLocalizer<Localized> Localized
+﻿@inject IStringLocalizer<Localized> Localized
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
 @inject NavigationManager NavigationManager
 @inject PatientMetricsBloodPressureService PatientMetricsBloodPressureService

--- a/PatientAnalytics/Blazor/Controllers/BlazorAlertController.cs
+++ b/PatientAnalytics/Blazor/Controllers/BlazorAlertController.cs
@@ -1,0 +1,21 @@
+using PatientAnalytics.Blazor.Models;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using PatientAnalytics.Blazor.Localization;
+
+namespace PatientAnalytics.Blazor.Controllers;
+
+public class BlazorAlertController
+{
+    public bool IsVisible => Modal is not null;
+    
+    public Modal? Modal { get; private set; }
+
+    public void OnDisplayAlert(IStringLocalizer<Localized> localized, string titleKey, Action handleProceed)
+    {
+        Modal = new Modal(localized, localized[titleKey], handleProceed, RemovalModal);
+    }
+
+    public void RemovalModal() => Modal = null;
+}

--- a/PatientAnalytics/Blazor/Controllers/BlazorAlertController.cs
+++ b/PatientAnalytics/Blazor/Controllers/BlazorAlertController.cs
@@ -10,9 +10,9 @@ public class BlazorAlertController
     
     public Alert? Alert { get; private set; }
 
-    public void OnDisplayAlert(IStringLocalizer<Localized> localized, string titleKey, Action handleProceed)
+    public void OnDisplayAlert(IStringLocalizer<Localized> localized, string titleKey, Action handleAction)
     {
-        Alert = new Alert(localized, localized[titleKey], handleProceed, RemovalModal);
+        Alert = new Alert(localized, localized[titleKey], handleAction, RemovalModal);
     }
 
     public void RemovalModal() => Alert = null;

--- a/PatientAnalytics/Blazor/Controllers/BlazorAlertController.cs
+++ b/PatientAnalytics/Blazor/Controllers/BlazorAlertController.cs
@@ -1,21 +1,19 @@
-using PatientAnalytics.Blazor.Models;
 using Microsoft.Extensions.Localization;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using PatientAnalytics.Blazor.Localization;
+using PatientAnalytics.Blazor.Models;
 
 namespace PatientAnalytics.Blazor.Controllers;
 
 public class BlazorAlertController
 {
-    public bool IsVisible => Modal is not null;
+    public bool IsVisible => Alert is not null;
     
-    public Modal? Modal { get; private set; }
+    public Alert? Alert { get; private set; }
 
     public void OnDisplayAlert(IStringLocalizer<Localized> localized, string titleKey, Action handleProceed)
     {
-        Modal = new Modal(localized, localized[titleKey], handleProceed, RemovalModal);
+        Alert = new Alert(localized, localized[titleKey], handleProceed, RemovalModal);
     }
 
-    public void RemovalModal() => Modal = null;
+    public void RemovalModal() => Alert = null;
 }

--- a/PatientAnalytics/Blazor/Localization/Localized.Designer.cs
+++ b/PatientAnalytics/Blazor/Localization/Localized.Designer.cs
@@ -14,7 +14,7 @@ namespace PatientAnalytics.Blazor.Localization {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Localized {
+    public class Localized {
         
         private static System.Resources.ResourceManager resourceMan;
         

--- a/PatientAnalytics/Blazor/Localization/Localized.Designer.cs
+++ b/PatientAnalytics/Blazor/Localization/Localized.Designer.cs
@@ -14,7 +14,7 @@ namespace PatientAnalytics.Blazor.Localization {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class Localized {
+    internal class Localized {
         
         private static System.Resources.ResourceManager resourceMan;
         
@@ -582,6 +582,42 @@ namespace PatientAnalytics.Blazor.Localization {
         internal static string SignalRMessage_UserLoggedOut {
             get {
                 return ResourceManager.GetString("SignalRMessage_UserLoggedOut", resourceCulture);
+            }
+        }
+        
+        internal static string Title_UserDashboard {
+            get {
+                return ResourceManager.GetString("Title_UserDashboard", resourceCulture);
+            }
+        }
+        
+        internal static string Button_UserEditAccountInfo {
+            get {
+                return ResourceManager.GetString("Button_UserEditAccountInfo", resourceCulture);
+            }
+        }
+        
+        internal static string Button_UserDeactivate {
+            get {
+                return ResourceManager.GetString("Button_UserDeactivate", resourceCulture);
+            }
+        }
+        
+        internal static string Button_UserActivate {
+            get {
+                return ResourceManager.GetString("Button_UserActivate", resourceCulture);
+            }
+        }
+        
+        internal static string Title_ActivateUser {
+            get {
+                return ResourceManager.GetString("Title_ActivateUser", resourceCulture);
+            }
+        }
+        
+        internal static string Title_DeactivateUser {
+            get {
+                return ResourceManager.GetString("Title_DeactivateUser", resourceCulture);
             }
         }
     }

--- a/PatientAnalytics/Blazor/Localization/Localized.Designer.cs
+++ b/PatientAnalytics/Blazor/Localization/Localized.Designer.cs
@@ -620,5 +620,11 @@ namespace PatientAnalytics.Blazor.Localization {
                 return ResourceManager.GetString("Title_DeactivateUser", resourceCulture);
             }
         }
+        
+        internal static string Title_DeleteRecord {
+            get {
+                return ResourceManager.GetString("Title_DeleteRecord", resourceCulture);
+            }
+        }
     }
 }

--- a/PatientAnalytics/Blazor/Localization/Localized.de.Designer.cs
+++ b/PatientAnalytics/Blazor/Localization/Localized.de.Designer.cs
@@ -14,7 +14,7 @@ namespace PatientAnalytics.Blazor.Localization {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Localized_de {
+    public class Localized_de {
         
         private static System.Resources.ResourceManager resourceMan;
         

--- a/PatientAnalytics/Blazor/Localization/Localized.de.Designer.cs
+++ b/PatientAnalytics/Blazor/Localization/Localized.de.Designer.cs
@@ -14,7 +14,7 @@ namespace PatientAnalytics.Blazor.Localization {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class Localized_de {
+    internal class Localized_de {
         
         private static System.Resources.ResourceManager resourceMan;
         
@@ -582,6 +582,42 @@ namespace PatientAnalytics.Blazor.Localization {
         internal static string SignalRMessage_UserLoggedOut {
             get {
                 return ResourceManager.GetString("SignalRMessage_UserLoggedOut", resourceCulture);
+            }
+        }
+        
+        internal static string Title_UserDashboard {
+            get {
+                return ResourceManager.GetString("Title_UserDashboard", resourceCulture);
+            }
+        }
+        
+        internal static string Button_UserEditAccountInfo {
+            get {
+                return ResourceManager.GetString("Button_UserEditAccountInfo", resourceCulture);
+            }
+        }
+        
+        internal static string Button_UserActivate {
+            get {
+                return ResourceManager.GetString("Button_UserActivate", resourceCulture);
+            }
+        }
+        
+        internal static string Button_UserDeactivate {
+            get {
+                return ResourceManager.GetString("Button_UserDeactivate", resourceCulture);
+            }
+        }
+        
+        internal static string Title_ActivateUser {
+            get {
+                return ResourceManager.GetString("Title_ActivateUser", resourceCulture);
+            }
+        }
+        
+        internal static string Title_DeactivateUser {
+            get {
+                return ResourceManager.GetString("Title_DeactivateUser", resourceCulture);
             }
         }
     }

--- a/PatientAnalytics/Blazor/Localization/Localized.de.Designer.cs
+++ b/PatientAnalytics/Blazor/Localization/Localized.de.Designer.cs
@@ -620,5 +620,11 @@ namespace PatientAnalytics.Blazor.Localization {
                 return ResourceManager.GetString("Title_DeactivateUser", resourceCulture);
             }
         }
+        
+        internal static string Title_DeleteRecord {
+            get {
+                return ResourceManager.GetString("Title_DeleteRecord", resourceCulture);
+            }
+        }
     }
 }

--- a/PatientAnalytics/Blazor/Localization/Localized.de.resx
+++ b/PatientAnalytics/Blazor/Localization/Localized.de.resx
@@ -288,4 +288,22 @@
     <data name="SignalRMessage_UserLoggedOut">
         <value>{0} hat sich abgemeldet.</value>
     </data>
+    <data name="Title_UserDashboard" xml:space="preserve">
+        <value>Benutzer-Dashboard</value>
+    </data>
+    <data name="Button_UserEditAccountInfo" xml:space="preserve">
+        <value>Kontoinformationen bearbeiten</value>
+    </data>
+    <data name="Button_UserActivate" xml:space="preserve">
+        <value>Benutzer aktivieren</value>
+    </data>
+    <data name="Button_UserDeactivate" xml:space="preserve">
+        <value>Benutzer deaktivieren</value>
+    </data>
+    <data name="Title_ActivateUser" xml:space="preserve">
+        <value>Benutzer aktivieren</value>
+    </data>
+    <data name="Title_DeactivateUser" xml:space="preserve">
+        <value>Benutzer deaktivieren</value>
+    </data>
 </root>

--- a/PatientAnalytics/Blazor/Localization/Localized.de.resx
+++ b/PatientAnalytics/Blazor/Localization/Localized.de.resx
@@ -306,4 +306,7 @@
     <data name="Title_DeactivateUser" xml:space="preserve">
         <value>Benutzer deaktivieren</value>
     </data>
+    <data name="Title_DeleteRecord" xml:space="preserve">
+        <value>Datensatz löschen</value>
+    </data>
 </root>

--- a/PatientAnalytics/Blazor/Localization/Localized.resx
+++ b/PatientAnalytics/Blazor/Localization/Localized.resx
@@ -306,4 +306,7 @@
     <data name="Title_DeactivateUser" xml:space="preserve">
         <value>Deactivate User</value>
     </data>
+    <data name="Title_DeleteRecord" xml:space="preserve">
+        <value>Delete Record</value>
+    </data>
 </root>

--- a/PatientAnalytics/Blazor/Localization/Localized.resx
+++ b/PatientAnalytics/Blazor/Localization/Localized.resx
@@ -288,4 +288,22 @@
     <data name="SignalRMessage_UserLoggedOut">
         <value>{0} has signed off.</value>
     </data>
+    <data name="Title_UserDashboard" xml:space="preserve">
+        <value>User Dashboard</value>
+    </data>
+    <data name="Button_UserEditAccountInfo" xml:space="preserve">
+        <value>Edit Account Info</value>
+    </data>
+    <data name="Button_UserDeactivate" xml:space="preserve">
+        <value>Deactivate User</value>
+    </data>
+    <data name="Button_UserActivate" xml:space="preserve">
+        <value>Activate User</value>
+    </data>
+    <data name="Title_ActivateUser" xml:space="preserve">
+        <value>Activate User</value>
+    </data>
+    <data name="Title_DeactivateUser" xml:space="preserve">
+        <value>Deactivate User</value>
+    </data>
 </root>

--- a/PatientAnalytics/Blazor/Localization/Localized.zh.Designer.cs
+++ b/PatientAnalytics/Blazor/Localization/Localized.zh.Designer.cs
@@ -14,7 +14,7 @@ namespace PatientAnalytics.Blazor.Localization {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class Localized_zh {
+    internal class Localized_zh {
         
         private static System.Resources.ResourceManager resourceMan;
         
@@ -582,6 +582,42 @@ namespace PatientAnalytics.Blazor.Localization {
         internal static string SignalRMessage_UserLoggedOut {
             get {
                 return ResourceManager.GetString("SignalRMessage_UserLoggedOut", resourceCulture);
+            }
+        }
+        
+        internal static string Title_UserDashboard {
+            get {
+                return ResourceManager.GetString("Title_UserDashboard", resourceCulture);
+            }
+        }
+        
+        internal static string Button_UserEditAccountInfo {
+            get {
+                return ResourceManager.GetString("Button_UserEditAccountInfo", resourceCulture);
+            }
+        }
+        
+        internal static string Button_UserActivate {
+            get {
+                return ResourceManager.GetString("Button_UserActivate", resourceCulture);
+            }
+        }
+        
+        internal static string Button_UserDeactivate {
+            get {
+                return ResourceManager.GetString("Button_UserDeactivate", resourceCulture);
+            }
+        }
+        
+        internal static string Title_DeactivateUser {
+            get {
+                return ResourceManager.GetString("Title_DeactivateUser", resourceCulture);
+            }
+        }
+        
+        internal static string Title_ActivateUser {
+            get {
+                return ResourceManager.GetString("Title_ActivateUser", resourceCulture);
             }
         }
     }

--- a/PatientAnalytics/Blazor/Localization/Localized.zh.Designer.cs
+++ b/PatientAnalytics/Blazor/Localization/Localized.zh.Designer.cs
@@ -14,7 +14,7 @@ namespace PatientAnalytics.Blazor.Localization {
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Localized_zh {
+    public class Localized_zh {
         
         private static System.Resources.ResourceManager resourceMan;
         

--- a/PatientAnalytics/Blazor/Localization/Localized.zh.Designer.cs
+++ b/PatientAnalytics/Blazor/Localization/Localized.zh.Designer.cs
@@ -620,5 +620,11 @@ namespace PatientAnalytics.Blazor.Localization {
                 return ResourceManager.GetString("Title_ActivateUser", resourceCulture);
             }
         }
+        
+        internal static string Title_DeleteRecord {
+            get {
+                return ResourceManager.GetString("Title_DeleteRecord", resourceCulture);
+            }
+        }
     }
 }

--- a/PatientAnalytics/Blazor/Localization/Localized.zh.resx
+++ b/PatientAnalytics/Blazor/Localization/Localized.zh.resx
@@ -288,4 +288,22 @@
     <data name="SignalRMessage_UserLoggedOut">
         <value>{0} 已登出。</value>
     </data>
+    <data name="Title_UserDashboard" xml:space="preserve">
+        <value>使用者介面</value>
+    </data>
+    <data name="Button_UserEditAccountInfo" xml:space="preserve">
+        <value>編輯帳戶資訊</value>
+    </data>
+    <data name="Button_UserActivate" xml:space="preserve">
+        <value>啟用用戶</value>
+    </data>
+    <data name="Button_UserDeactivate" xml:space="preserve">
+        <value>停用用戶</value>
+    </data>
+    <data name="Title_DeactivateUser" xml:space="preserve">
+        <value>停用用戶</value>
+    </data>
+    <data name="Title_ActivateUser" xml:space="preserve">
+        <value>啟用用戶</value>
+    </data>
 </root>

--- a/PatientAnalytics/Blazor/Localization/Localized.zh.resx
+++ b/PatientAnalytics/Blazor/Localization/Localized.zh.resx
@@ -306,4 +306,7 @@
     <data name="Title_ActivateUser" xml:space="preserve">
         <value>啟用用戶</value>
     </data>
+    <data name="Title_DeleteRecord" xml:space="preserve">
+        <value>刪除記錄</value>
+    </data>
 </root>

--- a/PatientAnalytics/Blazor/Models/Alert.cs
+++ b/PatientAnalytics/Blazor/Models/Alert.cs
@@ -3,9 +3,9 @@ using PatientAnalytics.Blazor.Localization;
 
 namespace PatientAnalytics.Blazor.Models;
 
-public class Modal
+public class Alert
 { 
-    public Modal(
+    public Alert(
         IStringLocalizer<Localized> localized,
         string title,
         Action onConfirm,

--- a/PatientAnalytics/Blazor/Models/Alert.cs
+++ b/PatientAnalytics/Blazor/Models/Alert.cs
@@ -11,8 +11,7 @@ public class Alert
         Action onConfirm,
         Action onCancel,
         string? confirmButtonText = null,
-        string? cancelButtonText = null
-        )
+        string? cancelButtonText = null)
     {
         Title = title;
         OnConfirm = onConfirm;

--- a/PatientAnalytics/Blazor/Models/Modal.cs
+++ b/PatientAnalytics/Blazor/Models/Modal.cs
@@ -27,7 +27,7 @@ public class Modal
     {
         return new Modal()
         {
-            Title = Localized["Title_Deactivate_User"],
+            Title = Localized["Title_DeactivateUser"],
             OnConfirm = onConfirm,
             OnCancel = onCancel
         };
@@ -37,7 +37,7 @@ public class Modal
     {
         return new Modal()
         {
-            Title = Localized["Title_Activate_User"],
+            Title = Localized["Title_ActivateUser"],
             OnConfirm = onConfirm,
             OnCancel = onCancel
         };

--- a/PatientAnalytics/Blazor/Models/Modal.cs
+++ b/PatientAnalytics/Blazor/Models/Modal.cs
@@ -1,45 +1,29 @@
-using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using PatientAnalytics.Blazor.Localization;
 
 namespace PatientAnalytics.Blazor.Models;
 
 public class Modal
-{
-    private static readonly IOptions<LocalizationOptions> LocalizationOptionsDefined =
-        Options.Create(new LocalizationOptions());
-
-    private static readonly ResourceManagerStringLocalizerFactory LocalizerFactory =
-        new(LocalizationOptionsDefined, NullLoggerFactory.Instance);
-    
-    private static readonly IStringLocalizer<Localized> Localized = 
-        new StringLocalizer<Localized>(LocalizerFactory);
-    
-    public string Title { get; private set; } = "";
-    public string ConfirmButtonText { get; private set; } = Localized["Button_Confirm"];
-    public string CancelButtonText { get; private set; } = Localized["Button_Cancel"];
-    public Action OnConfirm { get; private set; } = null!;
-    public Action OnCancel { get; private set; } = null!;
-
-    public static Modal ConfirmUserDeactivation(Action onConfirm, Action onCancel)
+{ 
+    public Modal(
+        IStringLocalizer<Localized> localized,
+        string title,
+        Action onConfirm,
+        Action onCancel,
+        string? confirmButtonText = null,
+        string? cancelButtonText = null
+        )
     {
-        return new Modal()
-        {
-            Title = Localized["Title_DeactivateUser"],
-            OnConfirm = onConfirm,
-            OnCancel = onCancel
-        };
+        Title = title;
+        OnConfirm = onConfirm;
+        OnCancel = onCancel;
+        ConfirmButtonText = confirmButtonText ?? localized["Button_Confirm"];
+        CancelButtonText = cancelButtonText ?? localized["Button_Cancel"];
     }
     
-    public static Modal ConfirmUserActivation(Action onConfirm, Action onCancel)
-    {
-        return new Modal()
-        {
-            Title = Localized["Title_ActivateUser"],
-            OnConfirm = onConfirm,
-            OnCancel = onCancel
-        };
-    }
+    public string Title { get; private set; }
+    public string ConfirmButtonText { get; private set; }
+    public string CancelButtonText { get; private set; }
+    public Action OnConfirm { get; private set; }
+    public Action OnCancel { get; private set; }
 }

--- a/PatientAnalytics/Blazor/Models/Modal.cs
+++ b/PatientAnalytics/Blazor/Models/Modal.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using PatientAnalytics.Blazor.Localization;
+
+namespace PatientAnalytics.Blazor.Models;
+
+public class Modal
+{
+    private static readonly IOptions<LocalizationOptions> LocalizationOptionsDefined =
+        Options.Create(new LocalizationOptions());
+
+    private static readonly ResourceManagerStringLocalizerFactory LocalizerFactory =
+        new(LocalizationOptionsDefined, NullLoggerFactory.Instance);
+    
+    private static readonly IStringLocalizer<Localized> Localized = 
+        new StringLocalizer<Localized>(LocalizerFactory);
+    
+    public string Title { get; private set; } = "";
+    public string ConfirmButtonText { get; private set; } = Localized["Button_Confirm"];
+    public string CancelButtonText { get; private set; } = Localized["Button_Cancel"];
+    public Action OnConfirm { get; private set; } = null!;
+    public Action OnCancel { get; private set; } = null!;
+
+    public static Modal ConfirmUserDeactivation(Action onConfirm, Action onCancel)
+    {
+        return new Modal()
+        {
+            Title = Localized["Title_Deactivate_User"],
+            OnConfirm = onConfirm,
+            OnCancel = onCancel
+        };
+    }
+    
+    public static Modal ConfirmUserActivation(Action onConfirm, Action onCancel)
+    {
+        return new Modal()
+        {
+            Title = Localized["Title_Activate_User"],
+            OnConfirm = onConfirm,
+            OnCancel = onCancel
+        };
+    }
+}

--- a/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
+++ b/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
@@ -30,15 +30,8 @@
                 }
             </div>
         </section>
-    
-        <section class="box">
-            <div class="container">
-                <h1 class="title">@Localized["Title_UserDashboard"]</h1>
-                <h2 class="title is-4">
-                    @string.Format(Localized["Format_FullName"], _user.FirstName, _user.LastName)
-                </h2>
-            </div>
-        </section>
+
+        <PersonDetailsDisplay Title="@Localized["Title_PatientDashboard"]" Person="_user" />
     }
     
     
@@ -82,12 +75,12 @@
 
     private void OnActivateUser()
     {
-        _modal = Modal.ConfirmUserDeactivation(async () => await HandleActivateUser(), () => _modal = null);
+        _modal = Modal.ConfirmUserActivation(async () => await HandleActivateUser(), () => _modal = null);
     }
 
     private void OnDeactivateUser()
     {
-        _modal = Modal.ConfirmUserActivation(async () => await HandleDeactivateUser(), () => _modal = null);
+        _modal = Modal.ConfirmUserDeactivation(async () => await HandleDeactivateUser(), () => _modal = null);
     }
 
     private async Task HandleActivateUser()

--- a/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
+++ b/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
@@ -16,24 +16,33 @@
                 <button class="button" @onclick="GoBack">@Localized["Button_Back"]</button>
             </div>
             <div class="is-flex is-gap-3">
+                <button class="button is-success" @onclick="() => _userEditModalRevealed = true">
+                    @Localized["Button_UserEditAccountInfo"]
+                </button>
                 @if (_user.IsDeactivated)
                 {
-                <button class="button is-primary is-outlined" @onclick="OnActivateUser">
-                    @Localized["Button_UserActivate"]
-                </button>
+                    <button class="button is-primary is-outlined" @onclick="OnActivateUser">
+                        @Localized["Button_UserActivate"]
+                    </button>
                 }
                 else
                 {
-                <button class="button is-danger is-outlined" @onclick="OnDeactivateUser">
-                    @Localized["Button_UserDeactivate"]
-                </button>
+                    <button class="button is-danger is-outlined" @onclick="OnDeactivateUser">
+                        @Localized["Button_UserDeactivate"]
+                    </button>
                 }
             </div>
         </section>
 
         <PersonDetailsDisplay Title="@Localized["Title_PatientDashboard"]" Person="_user" />
+        
+        <UserEditAccountInfoModal
+            IsModalOpen="@_userEditModalRevealed"
+            OnClose="() => _userEditModalRevealed = false"
+            OnUserEdited="user => _user = user"
+            User="_user"
+        />
     }
-    
     
     @if (_modal is not null)
     {
@@ -57,6 +66,7 @@
 
     private User? _user;
     private Modal? _modal;
+    private bool _userEditModalRevealed;
 
     protected override async Task OnInitializedAsync()
     {

--- a/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
+++ b/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
@@ -1,0 +1,94 @@
+@page "/user-management/users/{id:int}"
+@using PatientAnalytics.Blazor.Models
+@inject IStringLocalizer<Localized> Localized
+@inject NavigationManager NavigationManager
+@inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
+@inject UserService UserService
+
+<AdminDashboardWrapper>
+    <HttpStatusExceptionIndicator Exception="@_exception" />
+
+    @if (_user is not null)
+    {
+        <section class="box is-flex is-flex-direction-row is-justify-content-space-between">
+            <div class="is-flex">
+                <button class="button" @onclick="GoBack">@Localized["Button_Back"]</button>
+            </div>
+            <div class="is-flex is-gap-3">
+                @if (_user.IsDeactivated)
+                {
+                <button class="button is-primary is-outlined" @onclick="OnActivateUser">
+                    @Localized["Button_UserActivate"]
+                </button>
+                }
+                else
+                {
+                <button class="button is-danger is-outlined" @onclick="OnDeactivateUser">
+                    @Localized["Button_UserDeactivate"]
+                </button>
+                }
+            </div>
+        </section>
+    
+        <section class="box">
+            <div class="container">
+                <h1 class="title">@Localized["Title_UserDashboard"]</h1>
+                <h2 class="title is-4">
+                    @string.Format(Localized["Format_FullName"], _user.FirstName, _user.LastName)
+                </h2>
+            </div>
+        </section>
+    }
+    
+    
+    @if (_modal is not null)
+    {
+        <ConfirmationModal
+            Title="@_modal.Title"
+            ConfirmButtonText="@_modal.ConfirmButtonText"
+            CancelButtonText="@_modal.CancelButtonText"
+            OnConfirm="@_modal.OnConfirm"
+            OnCancel="@_modal.OnCancel"
+            IsVisible="true" />
+    }
+</AdminDashboardWrapper>
+
+
+@code {
+    [Parameter] 
+    public int Id { get; set; }
+    
+    private HttpStatusCodeException? _exception;
+    private bool _refreshing;
+
+    private User? _user;
+    private Modal? _modal;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (PatientAnalyticsAuthStateProvider.HasAdminPrivileges())
+        {
+            await PatientAnalyticsAuthStateProvider.ServiceWrapper(
+                _refreshing,
+                token => _user = UserService.GetUserById(token, Id),
+                refreshing => _refreshing = refreshing,
+                exception => _exception = exception, 
+                () => NavigationManager.NavigateTo("/"));
+        }
+    }
+
+    private void GoBack()
+    {
+        NavigationManager.NavigateTo("/dashboard/admin");
+    }
+
+    private void OnActivateUser()
+    {
+        _modal = Modal.ConfirmUserDeactivation(() => { }, () => _modal = null);
+    }
+
+    private void OnDeactivateUser()
+    {
+        _modal = Modal.ConfirmUserActivation(() => { }, () => _modal = null);
+    }
+}

--- a/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
+++ b/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
@@ -44,16 +44,7 @@
         />
     }
     
-    @if (_alertController.IsVisible)
-    {
-        <ConfirmationModal
-            Title="@_alertController.Alert!.Title"
-            ConfirmButtonText="@_alertController.Alert.ConfirmButtonText"
-            CancelButtonText="@_alertController.Alert.CancelButtonText"
-            OnConfirm="@_alertController.Alert.OnConfirm"
-            OnCancel="@_alertController.Alert.OnCancel"
-            IsVisible="true" />
-    }
+    <ConfirmationModal Alert="_alertController.Alert" />
 </AdminDashboardWrapper>
 
 

--- a/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
+++ b/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
@@ -1,6 +1,5 @@
 @page "/user-management/users/{id:int}"
 @using PatientAnalytics.Blazor.Controllers
-@using PatientAnalytics.Blazor.Models
 @inject IStringLocalizer<Localized> Localized
 @inject NavigationManager NavigationManager
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
@@ -48,11 +47,11 @@
     @if (_alertController.IsVisible)
     {
         <ConfirmationModal
-            Title="@_alertController.Modal!.Title"
-            ConfirmButtonText="@_alertController.Modal.ConfirmButtonText"
-            CancelButtonText="@_alertController.Modal.CancelButtonText"
-            OnConfirm="@_alertController.Modal.OnConfirm"
-            OnCancel="@_alertController.Modal.OnCancel"
+            Title="@_alertController.Alert!.Title"
+            ConfirmButtonText="@_alertController.Alert.ConfirmButtonText"
+            CancelButtonText="@_alertController.Alert.CancelButtonText"
+            OnConfirm="@_alertController.Alert.OnConfirm"
+            OnCancel="@_alertController.Alert.OnCancel"
             IsVisible="true" />
     }
 </AdminDashboardWrapper>

--- a/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
+++ b/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
@@ -1,5 +1,4 @@
 @page "/user-management/users/{id:int}"
-@using PatientAnalytics.Blazor.Controllers
 @inject IStringLocalizer<Localized> Localized
 @inject NavigationManager NavigationManager
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider

--- a/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
+++ b/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
@@ -1,4 +1,5 @@
 @page "/user-management/users/{id:int}"
+@using PatientAnalytics.Blazor.Controllers
 @using PatientAnalytics.Blazor.Models
 @inject IStringLocalizer<Localized> Localized
 @inject NavigationManager NavigationManager
@@ -44,14 +45,14 @@
         />
     }
     
-    @if (_modal is not null)
+    @if (_alertController.IsVisible)
     {
         <ConfirmationModal
-            Title="@_modal.Title"
-            ConfirmButtonText="@_modal.ConfirmButtonText"
-            CancelButtonText="@_modal.CancelButtonText"
-            OnConfirm="@_modal.OnConfirm"
-            OnCancel="@_modal.OnCancel"
+            Title="@_alertController.Modal!.Title"
+            ConfirmButtonText="@_alertController.Modal.ConfirmButtonText"
+            CancelButtonText="@_alertController.Modal.CancelButtonText"
+            OnConfirm="@_alertController.Modal.OnConfirm"
+            OnCancel="@_alertController.Modal.OnCancel"
             IsVisible="true" />
     }
 </AdminDashboardWrapper>
@@ -65,8 +66,9 @@
     private bool _refreshing;
 
     private User? _user;
-    private Modal? _modal;
     private bool _userEditModalRevealed;
+
+    private readonly BlazorAlertController _alertController = new();
 
     protected override async Task OnInitializedAsync()
     {
@@ -85,12 +87,18 @@
 
     private void OnActivateUser()
     {
-        _modal = Modal.ConfirmUserActivation(async () => await HandleActivateUser(), () => _modal = null);
+        _alertController.OnDisplayAlert(
+            Localized, 
+            "Title_ActivateUser", 
+            async () => await HandleActivateUser());
     }
 
     private void OnDeactivateUser()
     {
-        _modal = Modal.ConfirmUserDeactivation(async () => await HandleDeactivateUser(), () => _modal = null);
+        _alertController.OnDisplayAlert(
+            Localized, 
+            "Title_DeactivateUser", 
+            async () => await HandleDeactivateUser());
     }
 
     private async Task HandleActivateUser()
@@ -101,7 +109,7 @@
             {
                 await UserService.ActivateUser(token, Id);
                 
-                _modal = null;
+                _alertController.RemovalModal();
                 
                 if (_user is not null) _user.IsDeactivated = false;
             },
@@ -118,7 +126,7 @@
             {
                 await UserService.DeactivateUser(token, Id);
                 
-                _modal = null;
+                _alertController.RemovalModal();
                 
                 if (_user is not null) _user.IsDeactivated = true;
             },

--- a/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
+++ b/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
@@ -34,7 +34,7 @@
             </div>
         </section>
 
-        <PersonDetailsDisplay Title="@Localized["Title_PatientDashboard"]" Person="_user" />
+        <PersonDetailsDisplay Title="@Localized["Title_UserDashboard"]" Person="_user" />
         
         <UserEditAccountInfoModal
             IsModalOpen="@_userEditModalRevealed"

--- a/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
+++ b/PatientAnalytics/Blazor/Pages/Admin/UserManagement/UserManagement.razor
@@ -4,6 +4,7 @@
 @inject NavigationManager NavigationManager
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
 @inject UserService UserService
+@inject IJSRuntime JSRuntime
 
 <AdminDashboardWrapper>
     <HttpStatusExceptionIndicator Exception="@_exception" />
@@ -77,18 +78,49 @@
         }
     }
 
-    private void GoBack()
-    {
-        NavigationManager.NavigateTo("/dashboard/admin");
-    }
+    private async void GoBack() => await JSRuntime.InvokeVoidAsync("history.back");
 
     private void OnActivateUser()
     {
-        _modal = Modal.ConfirmUserDeactivation(() => { }, () => _modal = null);
+        _modal = Modal.ConfirmUserDeactivation(async () => await HandleActivateUser(), () => _modal = null);
     }
 
     private void OnDeactivateUser()
     {
-        _modal = Modal.ConfirmUserActivation(() => { }, () => _modal = null);
+        _modal = Modal.ConfirmUserActivation(async () => await HandleDeactivateUser(), () => _modal = null);
+    }
+
+    private async Task HandleActivateUser()
+    {
+        await PatientAnalyticsAuthStateProvider.ServiceWrapperAsync(
+            _refreshing,
+            async token =>
+            {
+                await UserService.ActivateUser(token, Id);
+                
+                _modal = null;
+                
+                if (_user is not null) _user.IsDeactivated = false;
+            },
+            refreshing => _refreshing = refreshing,
+            exception => _exception = exception,
+            () => NavigationManager.NavigateTo("/"));
+    }
+    
+    private async Task HandleDeactivateUser()
+    {
+        await PatientAnalyticsAuthStateProvider.ServiceWrapperAsync(
+            _refreshing,
+            async token =>
+            {
+                await UserService.DeactivateUser(token, Id);
+                
+                _modal = null;
+                
+                if (_user is not null) _user.IsDeactivated = true;
+            },
+            refreshing => _refreshing = refreshing,
+            exception => _exception = exception,
+            () => NavigationManager.NavigateTo("/"));
     }
 }

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientDashboard.razor
@@ -1,4 +1,5 @@
 ﻿@page "/dashboard/doctor/patients/{id:int}"
+@using PatientAnalytics.Blazor.Controllers
 @inject IStringLocalizer<Localized> Localized
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
 @inject NavigationManager NavigationManager
@@ -17,7 +18,7 @@
             </div>
             <div class ="is-flex is-gap-3">
                 <button class="button is-success" @onclick="ToggleUpdateDetails">@(_updateDetails ? Localized["Button_Cancel"] : Localized["Button_Edit"])</button>
-                <button class="button is-danger is-outlined" @onclick="ShowDeleteConfirmation">@Localized["Button_Delete"]</button>
+                <button class="button is-danger is-outlined" @onclick="OnDelete">@Localized["Button_Delete"]</button>
             </div>
             <div>
                 <button disabled="@_isDownloadReportDisabled" class="button" @onclick="GetReport">@Localized["Button_Download_Report"]</button>
@@ -40,13 +41,7 @@
 
     <HttpStatusExceptionIndicator Exception="@_exception" />
     
-    <ConfirmationModal
-        Title="@Localized["Title_Delete_Patient"]"
-        ConfirmButtonText="@Localized["Button_Delete"]"
-        CancelButtonText="@Localized["Button_Cancel"]"
-        IsVisible="@_isDeleteConfirmationVisible"
-        OnConfirm="ConfirmDelete"
-        OnCancel="HideDeleteConfirmation" />
+    <ConfirmationModal Alert="_alertController.Alert" />
 </DoctorDashboardWrapper>
 
 @code {
@@ -56,8 +51,9 @@
     
     private Patient? _patient;
     private bool _updateDetails;
-    private bool _isDeleteConfirmationVisible;
     private bool _isDownloadReportDisabled = true;
+    
+    private readonly BlazorAlertController _alertController = new();
     
     private bool _refreshing;
     private HttpStatusCodeException? _exception;
@@ -121,14 +117,12 @@
         NavigationManager.NavigateTo("/dashboard/doctor");
     }
 
-    private void ShowDeleteConfirmation()
+    private void OnDelete()
     {
-        _isDeleteConfirmationVisible = true;
-    }
-
-    private void HideDeleteConfirmation()
-    {
-        _isDeleteConfirmationVisible = false;
+        _alertController.OnDisplayAlert(
+            Localized,
+            "Title_Delete_Patient",
+            async () => await ConfirmDelete());
     }
 
     private async Task ConfirmDelete()

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientDashboard.razor
@@ -24,29 +24,7 @@
             </div>
         </section>
         
-        <section class="box">
-            <div class="container">
-                <h1 class="title">@Localized["Title_PatientDashboard"]</h1>
-                <h2 class="title is-4">
-                    @string.Format(Localized["Format_FullName"], _patient.FirstName, _patient.LastName)
-                </h2>
-                <ContentWithLabel Label="@Localized["Label_Email"]">@_patient.Email</ContentWithLabel>
-                <ContentWithLabel Label="@Localized["Label_Gender"]">@_patient.Gender</ContentWithLabel>
-                <ContentWithLabel Label="@Localized["Label_DateOfBirth"]">
-                    @_patient.DateOfBirth.ToString(Localized["DateFormatting_Date"])
-                </ContentWithLabel>
-                <ContentWithLabel Label="@Localized["Label_Address"]">@_patient.Address</ContentWithLabel>
-
-                <div class="divider"></div>
-
-                <ContentWithLabel Label="@Localized["Label_DateCreated"]">
-                    @_patient.DateCreated.ToString(Localized["DateFormatting_DateTime"])
-                </ContentWithLabel>
-                <ContentWithLabel Label="@Localized["Label_DateEdited"]">
-                    @_patient.DateEdited?.ToString(Localized["DateFormatting_DateTime"])
-                </ContentWithLabel>
-            </div>
-        </section>
+        <PersonDetailsDisplay Title="@Localized["Title_PatientDashboard"]" Person="_patient" />
 
         <section class="box is-flex is-flex-direction-row is-justify-content-space-between">
             <div class="buttons">

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientDashboard.razor
@@ -1,5 +1,4 @@
 ﻿@page "/dashboard/doctor/patients/{id:int}"
-@using PatientAnalytics.Blazor.Controllers
 @inject IStringLocalizer<Localized> Localized
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
 @inject NavigationManager NavigationManager

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsBloodPressureDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsBloodPressureDashboard.razor
@@ -1,4 +1,5 @@
 ﻿@page "/patients/{id:int}/bloodpressure"
+@using PatientAnalytics.Blazor.Controllers
 @using PatientAnalytics.Models.PatientMetrics
 @using PatientAnalytics.Services.PatientMetrics
 @inject IStringLocalizer<Localized> Localized
@@ -39,7 +40,11 @@
                                     <td>@patient.Status</td>
                                     <td>@patient.Doctor?.FirstName @patient.Doctor?.LastName @patient.DoctorId</td>
                                     <td>@patient.DateCreated</td>
-                                    <td><button class="button" @onclick="() => ShowDeleteConfirmation(patient.Id)">@Localized["Button_Delete"]</button></td>
+                                    <td>
+                                        <button class="button" @onclick="() => ShowDeleteConfirmation(patient.Id)">
+                                            @Localized["Button_Delete"]
+                                        </button>
+                                    </td>
                                 </tr>
                             }
                         </tbody>
@@ -66,14 +71,9 @@
     }
 
     <HttpStatusExceptionIndicator Exception="@_exception" />
-</DoctorDashboardWrapper>
 
-<ConfirmationModal Title="@($"{Localized["Title_Delete_Patient"]} {Localized["Button_BloodPressure"]}")"
-                   ConfirmButtonText="@Localized["Button_Delete"]"
-                   CancelButtonText="@Localized["Button_Cancel"]"
-                   IsVisible="@_isDeleteConfirmationVisible"
-                   OnConfirm="ConfirmDelete"
-                   OnCancel="HideDeleteConfirmation" />
+    <ConfirmationModal Alert="_alertController.Alert" />
+</DoctorDashboardWrapper>
 
 @code {
     [Parameter]
@@ -85,8 +85,8 @@
     
     private bool _refreshing;
     private HttpStatusCodeException? _exception;
-    
-    private bool _isDeleteConfirmationVisible;
+
+    private readonly BlazorAlertController _alertController = new();
     private string ErrorMessage { get; set; } = string.Empty;
 
     private int? _bloodPressureSystolic;
@@ -154,12 +154,10 @@
     private void ShowDeleteConfirmation(int id)
     {
         _bloodPressureId = id;
-        _isDeleteConfirmationVisible = true;
-    }
-
-    private void HideDeleteConfirmation()
-    {
-        _isDeleteConfirmationVisible = false;
+        _alertController.OnDisplayAlert(
+            Localized,
+            "Title_DeleteRecord",
+            async () => await ConfirmDelete());
     }
 
     private async Task ConfirmDelete()
@@ -171,7 +169,7 @@
                 await PatientMetricsBloodPressureService.DeleteEntryById(token, _bloodPressureId);
                 _patientsBloodPressure.RemoveAll(bp => bp.Id == _bloodPressureId);
                 
-                _isDeleteConfirmationVisible = false;
+                _alertController.RemovalModal();
             },
             refreshing => _refreshing = refreshing,
             exception => _exception = exception, 

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsBloodPressureDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsBloodPressureDashboard.razor
@@ -1,7 +1,4 @@
 ﻿@page "/patients/{id:int}/bloodpressure"
-@using PatientAnalytics.Blazor.Controllers
-@using PatientAnalytics.Models.PatientMetrics
-@using PatientAnalytics.Services.PatientMetrics
 @inject IStringLocalizer<Localized> Localized
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
 @inject NavigationManager NavigationManager

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsHeightDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsHeightDashboard.razor
@@ -1,5 +1,6 @@
 ﻿@page "/patients/{id:int}/height"
 @inject IStringLocalizer<Localized> Localized
+@using PatientAnalytics.Blazor.Controllers
 @using PatientAnalytics.Services.PatientMetrics
 @using PatientAnalytics.Models.PatientMetrics
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
@@ -95,14 +96,9 @@
     }
 
     <HttpStatusExceptionIndicator Exception="@_exception" />
-</DoctorDashboardWrapper>
 
-<ConfirmationModal Title="@($"{Localized["Title_Delete_Patient"]} {Localized["Button_Height"]}")"
-                   ConfirmButtonText="@Localized["Button_Delete"]"
-                   CancelButtonText="@Localized["Button_Cancel"]"
-                   IsVisible="@_isDeleteConfirmationVisible"
-                   OnConfirm="ConfirmDelete"
-                   OnCancel="HideDeleteConfirmation"/>
+    <ConfirmationModal Alert="_alertController.Alert" />
+</DoctorDashboardWrapper>
 
 @code {
     [Parameter]
@@ -114,8 +110,8 @@
     
     private bool _refreshing;
     private HttpStatusCodeException? _exception;
-    
-    private bool _isDeleteConfirmationVisible;
+
+    private readonly BlazorAlertController _alertController = new();
     private string ErrorMessage { get; set; } = string.Empty;
 
     private double? _heightValue;
@@ -187,12 +183,10 @@
     private void ShowDeleteConfirmation(int id)
     {
         _heightId = id;
-        _isDeleteConfirmationVisible = true;
-    }
-
-    private void HideDeleteConfirmation()
-    {
-        _isDeleteConfirmationVisible = false;
+        _alertController.OnDisplayAlert(
+            Localized, 
+            "Title_DeleteRecord", 
+            async () => ConfirmDelete());
     }
 
     private async Task ConfirmDelete()
@@ -204,7 +198,7 @@
                 await PatientMetricsHeightService.DeleteEntryById(token, _heightId);
                 _patientsHeight.RemoveAll(bp => bp.Id == _heightId);
                 
-                _isDeleteConfirmationVisible = false;
+                _alertController.RemovalModal();
             },
             refreshing => _refreshing = refreshing,
             exception => _exception = exception, 

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsHeightDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsHeightDashboard.razor
@@ -1,8 +1,5 @@
 ﻿@page "/patients/{id:int}/height"
 @inject IStringLocalizer<Localized> Localized
-@using PatientAnalytics.Blazor.Controllers
-@using PatientAnalytics.Services.PatientMetrics
-@using PatientAnalytics.Models.PatientMetrics
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
 @inject NavigationManager NavigationManager
 @inject PatientService PatientService

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsTemperatureDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsTemperatureDashboard.razor
@@ -1,5 +1,6 @@
 ﻿@page "/patients/{id:int}/temperature"
 @inject IStringLocalizer<Localized> Localized
+@using PatientAnalytics.Blazor.Controllers
 @using PatientAnalytics.Services.PatientMetrics
 @using PatientAnalytics.Models.PatientMetrics
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
@@ -87,14 +88,9 @@
     }
 
     <HttpStatusExceptionIndicator Exception="@_exception" />
-</DoctorDashboardWrapper>
 
-<ConfirmationModal Title="@($"{Localized["Title_Delete_Patient"]} {Localized["Button_Temperature"]}")"
-                   ConfirmButtonText="@Localized["Button_Delete"]"
-                   CancelButtonText="@Localized["Button_Cancel"]"
-                   IsVisible="@_isDeleteConfirmationVisible"
-                   OnConfirm="ConfirmDelete"
-                   OnCancel="HideDeleteConfirmation" />
+    <ConfirmationModal Alert="_alertController.Alert" />
+</DoctorDashboardWrapper>
 
 @code {
     [Parameter]
@@ -106,8 +102,8 @@
     
     private bool _refreshing;
     private HttpStatusCodeException? _exception;
-    
-    private bool _isDeleteConfirmationVisible;
+
+    private readonly BlazorAlertController _alertController = new();
     private string ErrorMessage { get; set; } = string.Empty;
 
     private double? _temperatureValue;
@@ -180,12 +176,10 @@
     private void ShowDeleteConfirmation(int id)
     {
         _temperatureId = id;
-        _isDeleteConfirmationVisible = true;
-    }
-
-    private void HideDeleteConfirmation()
-    {
-        _isDeleteConfirmationVisible = false;
+        _alertController.OnDisplayAlert(
+            Localized,
+            "Title_DeleteRecord",
+            async () => await ConfirmDelete());
     }
 
     private async Task ConfirmDelete()
@@ -197,7 +191,7 @@
                 await PatientMetricsTemperatureService.DeleteEntryById(token, _temperatureId);
                 _patientsTemperature.RemoveAll(bp => bp.Id == _temperatureId);
                 
-                _isDeleteConfirmationVisible = false;
+                _alertController.RemovalModal();
             },
             refreshing => _refreshing = refreshing,
             exception => _exception = exception, 

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsTemperatureDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsTemperatureDashboard.razor
@@ -1,8 +1,5 @@
 ﻿@page "/patients/{id:int}/temperature"
 @inject IStringLocalizer<Localized> Localized
-@using PatientAnalytics.Blazor.Controllers
-@using PatientAnalytics.Services.PatientMetrics
-@using PatientAnalytics.Models.PatientMetrics
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
 @inject NavigationManager NavigationManager
 @inject PatientService PatientService

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsWeightDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsWeightDashboard.razor
@@ -1,5 +1,6 @@
 ﻿@page "/patients/{id:int}/weight"
 @inject IStringLocalizer<Localized> Localized
+@using PatientAnalytics.Blazor.Controllers
 @using PatientAnalytics.Services.PatientMetrics
 @using PatientAnalytics.Models.PatientMetrics
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
@@ -91,14 +92,9 @@
     }
 
     <HttpStatusExceptionIndicator Exception="@_exception"/>
-</DoctorDashboardWrapper>
 
-<ConfirmationModal Title="@($"{Localized["Title_Delete_Patient"]} {Localized["Button_Weight"]}")"
-                   ConfirmButtonText="@Localized["Button_Delete"]"
-                   CancelButtonText="@Localized["Button_Cancel"]"
-                   IsVisible="@_isDeleteConfirmationVisible"
-                   OnConfirm="ConfirmDelete"
-                   OnCancel="HideDeleteConfirmation" />
+    <ConfirmationModal Alert="_alertController.Alert" />
+</DoctorDashboardWrapper>
 
 @code {
     [Parameter]
@@ -110,8 +106,8 @@
     
     private bool _refreshing;
     private HttpStatusCodeException? _exception;
-    
-    private bool _isDeleteConfirmationVisible;
+
+    private readonly BlazorAlertController _alertController = new();
     private string ErrorMessage { get; set; } = string.Empty;
 
     private double? _weightValue;
@@ -184,12 +180,10 @@
     private void ShowDeleteConfirmation(int id)
     {
         _weightId = id;
-        _isDeleteConfirmationVisible = true;
-    }
-
-    private void HideDeleteConfirmation()
-    {
-        _isDeleteConfirmationVisible = false;
+        _alertController.OnDisplayAlert(
+            Localized,
+            "Title_DeleteRecord",
+            async () => await ConfirmDelete());
     }
 
     private async Task ConfirmDelete()
@@ -201,7 +195,7 @@
                 await PatientMetricsWeightService.DeleteEntryById(token, _weightId);
                 _patientsWeight.RemoveAll(bp => bp.Id == _weightId);
                 
-                _isDeleteConfirmationVisible = false;
+                _alertController.RemovalModal();
             },
             refreshing => _refreshing = refreshing,
             exception => _exception = exception, 

--- a/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsWeightDashboard.razor
+++ b/PatientAnalytics/Blazor/Pages/Doctor/PatientMetrics/PatientMetricsWeightDashboard.razor
@@ -1,8 +1,5 @@
 ﻿@page "/patients/{id:int}/weight"
 @inject IStringLocalizer<Localized> Localized
-@using PatientAnalytics.Blazor.Controllers
-@using PatientAnalytics.Services.PatientMetrics
-@using PatientAnalytics.Models.PatientMetrics
 @inject PatientAnalyticsAuthStateProvider PatientAnalyticsAuthStateProvider
 @inject NavigationManager NavigationManager
 @inject PatientService PatientService

--- a/PatientAnalytics/Blazor/_Imports.razor
+++ b/PatientAnalytics/Blazor/_Imports.razor
@@ -1,7 +1,9 @@
 @using System.Net.Http
 @using System.Net.Http.Json
 @using System.Security.Claims
+@using Blazor.Controllers
 @using Blazor.Localization
+@using Blazor.Models
 @using Blazored.Toast
 @using Blazored.Toast.Configuration
 @using Blazored.Toast.Services
@@ -23,4 +25,6 @@
 @using PatientAnalytics.Middleware
 @using PatientAnalytics.Models
 @using PatientAnalytics.Models.Auth
+@using PatientAnalytics.Models.PatientMetrics
 @using PatientAnalytics.Services
+@using PatientAnalytics.Services.PatientMetrics

--- a/PatientAnalytics/Controllers/UserController.cs
+++ b/PatientAnalytics/Controllers/UserController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using PatientAnalytics.Middleware;
 using PatientAnalytics.Models;
-using PatientAnalytics.Models.Auth;
 using PatientAnalytics.Services;
 using PatientAnalytics.Utils.Localization;
 
@@ -15,16 +14,13 @@ namespace PatientAnalytics.Controllers;
 [Route("/api")]
 public class UserController
 {
-    private readonly RegistrationService _registrationService;
     private readonly UserService _userService;
     private readonly IStringLocalizer<ApiResponseLocalized> _localized;
 
     public UserController(
-        RegistrationService registrationService,
         UserService userService,
         IStringLocalizer<ApiResponseLocalized> localized)
     {
-        _registrationService = registrationService;
         _userService = userService;
         _localized = localized;
     }
@@ -55,6 +51,26 @@ public class UserController
         ValidateAuthorization(httpContextAccessor, out var authorization);
 
         return _userService.GetSuperAdmins(authorization);
+    }
+
+    [HttpPut("user/{userId:int}/deactivate", Name = "DeactivateUser")]
+    public async Task<IActionResult> DeactivateUser(
+        [FromServices] IHttpContextAccessor httpContextAccessor,
+        [FromRoute] int userId)
+    {
+        ValidateAuthorization(httpContextAccessor, out var authorization);
+
+        return await _userService.DeactivateUser(authorization, userId);
+    }
+    
+    [HttpPut("user/{userId:int}/activate", Name = "ActivateUser")]
+    public async Task<IActionResult> ActivateUser(
+        [FromServices] IHttpContextAccessor httpContextAccessor,
+        [FromRoute] int userId)
+    {
+        ValidateAuthorization(httpContextAccessor, out var authorization);
+
+        return await _userService.ActivateUser(authorization, userId);
     }
 
     private void ValidateAuthorization(IHttpContextAccessor httpContextAccessor, out string verifiedAuthorization)

--- a/PatientAnalytics/Controllers/UserController.cs
+++ b/PatientAnalytics/Controllers/UserController.cs
@@ -53,7 +53,17 @@ public class UserController
         return _userService.GetSuperAdmins(authorization);
     }
 
-    [HttpPut("user/{userId:int}", Name = "EditUserAccountInfo")]
+    [HttpGet("users/{userId:int}", Name = "GetUserById")]
+    public User GetUserBydId(
+        [FromServices] IHttpContextAccessor httpContextAccessor,
+        [FromRoute] int userId)
+    {
+        ValidateAuthorization(httpContextAccessor, out var authorization);
+
+        return _userService.GetUserById(authorization, userId);
+    }
+    
+    [HttpPut("users/{userId:int}", Name = "EditUserAccountInfo")]
     public async Task<User> EditUserAccountInfo(
         [FromServices] IHttpContextAccessor httpContextAccessor,
         [FromRoute] int userId,
@@ -64,7 +74,7 @@ public class UserController
         return await _userService.EditUserAccountInfo(authorization, userId, payload);
     }
 
-    [HttpPut("user/{userId:int}/deactivate", Name = "DeactivateUser")]
+    [HttpPut("users/{userId:int}/deactivate", Name = "DeactivateUser")]
     public async Task<IActionResult> DeactivateUser(
         [FromServices] IHttpContextAccessor httpContextAccessor,
         [FromRoute] int userId)
@@ -74,7 +84,7 @@ public class UserController
         return await _userService.DeactivateUser(authorization, userId);
     }
     
-    [HttpPut("user/{userId:int}/activate", Name = "ActivateUser")]
+    [HttpPut("users/{userId:int}/activate", Name = "ActivateUser")]
     public async Task<IActionResult> ActivateUser(
         [FromServices] IHttpContextAccessor httpContextAccessor,
         [FromRoute] int userId)

--- a/PatientAnalytics/Controllers/UserController.cs
+++ b/PatientAnalytics/Controllers/UserController.cs
@@ -53,6 +53,17 @@ public class UserController
         return _userService.GetSuperAdmins(authorization);
     }
 
+    [HttpPut("user/{userId:int}", Name = "EditUserAccountInfo")]
+    public async Task<User> EditUserAccountInfo(
+        [FromServices] IHttpContextAccessor httpContextAccessor,
+        [FromRoute] int userId,
+        [FromBody] UserAccountInfoPayload payload)
+    {
+        ValidateAuthorization(httpContextAccessor, out var authorization);
+
+        return await _userService.EditUserAccountInfo(authorization, userId, payload);
+    }
+
     [HttpPut("user/{userId:int}/deactivate", Name = "DeactivateUser")]
     public async Task<IActionResult> DeactivateUser(
         [FromServices] IHttpContextAccessor httpContextAccessor,

--- a/PatientAnalytics/Migrations/20240819181800_AddIsDeactivatedToUser.Designer.cs
+++ b/PatientAnalytics/Migrations/20240819181800_AddIsDeactivatedToUser.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PatientAnalytics.Models;
 
@@ -10,9 +11,11 @@ using PatientAnalytics.Models;
 namespace PatientAnalytics.Migrations
 {
     [DbContext(typeof(Context))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20240819181800_AddIsDeactivatedToUser")]
+    partial class AddIsDeactivatedToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.6");

--- a/PatientAnalytics/Migrations/20240819181800_AddIsDeactivatedToUser.cs
+++ b/PatientAnalytics/Migrations/20240819181800_AddIsDeactivatedToUser.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PatientAnalytics.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsDeactivatedToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeactivated",
+                table: "Users",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDeactivated",
+                table: "Users");
+        }
+    }
+}

--- a/PatientAnalytics/Models/Person.cs
+++ b/PatientAnalytics/Models/Person.cs
@@ -18,22 +18,8 @@ public class Person
     public DateTime? DateEdited { get; set; }
 }
 
-public class PersonPayload
+public class PersonPayload : UserAccountInfoPayload
 {
-    [Required(ErrorMessage = "Date of Birth is required.")]
-    public DateTime DateOfBirth { get; set; } = DateTime.Now;
-    
-    [Required(ErrorMessage = "Gender is required.")]
-    public string Gender { get; set; } = null!;
-    
-    [Required(ErrorMessage = "First Name is required.")]
-    public string? FirstName { get; set; }
-    
-    [Required(ErrorMessage = "Last Name is required.")]
-    public string? LastName { get; set; }
-    
     [Required(ErrorMessage = "Email is required."), RegularExpression(@"^([\w\.\-]+)@([\w\-]+)((\.(\w){2,3})+)$", ErrorMessage = "Email format is invalid")]
     public string Email { get; set; } = null!;
-    
-    public string? Address { get; set; }
 }

--- a/PatientAnalytics/Models/User.cs
+++ b/PatientAnalytics/Models/User.cs
@@ -28,6 +28,16 @@ public class User : Person
         };
     }
 
+    public void Deactivate()
+    {
+        IsDeactivated = true;
+    }
+
+    public void Activate()
+    {
+        IsDeactivated = false;
+    }
+
     [MaxLength(30)]
     public string Username { get; set; } = null!;
     

--- a/PatientAnalytics/Models/User.cs
+++ b/PatientAnalytics/Models/User.cs
@@ -28,6 +28,16 @@ public class User : Person
         };
     }
 
+    public void UpdateAccountInfo(UserAccountInfoPayload payload)
+    {
+        DateOfBirth = payload.DateOfBirth;
+        Gender = payload.Gender;
+        Address = payload.Address;
+        FirstName = payload.FirstName;
+        LastName = payload.LastName;
+        DateEdited = DateTime.Now;
+    }
+
     public void Deactivate()
     {
         IsDeactivated = true;
@@ -50,4 +60,21 @@ public class User : Person
     public bool IsDeactivated { get; set; }
     
     public ICollection<UserRefresh> UserRefreshes { get; } = new List<UserRefresh>();
+}
+
+public class UserAccountInfoPayload
+{
+    [Required(ErrorMessage = "Date of Birth is required.")]
+    public DateTime DateOfBirth { get; set; } = DateTime.Now;
+    
+    [Required(ErrorMessage = "Gender is required.")]
+    public string Gender { get; set; } = null!;
+    
+    [Required(ErrorMessage = "First Name is required.")]
+    public string? FirstName { get; set; }
+    
+    [Required(ErrorMessage = "Last Name is required.")]
+    public string? LastName { get; set; }
+    
+    public string? Address { get; set; }
 }

--- a/PatientAnalytics/Models/User.cs
+++ b/PatientAnalytics/Models/User.cs
@@ -77,4 +77,16 @@ public class UserAccountInfoPayload
     public string? LastName { get; set; }
     
     public string? Address { get; set; }
+
+    public static UserAccountInfoPayload CreatePayloadFromUser(User user)
+    {
+        return new UserAccountInfoPayload
+        {
+            DateOfBirth = user.DateOfBirth,
+            Gender = user.Gender,
+            FirstName = user.FirstName,
+            LastName = user.LastName,
+            Address = user.Address
+        };
+    }
 }

--- a/PatientAnalytics/Models/User.cs
+++ b/PatientAnalytics/Models/User.cs
@@ -36,6 +36,8 @@ public class User : Person
     
     [MaxLength(30), RegularExpression("^SuperAdmin$|^Admin$|^Doctor$", ErrorMessage = "Invalid Role Value. Role Value can either be SuperAdmin, Admin or Doctor")]
     public string Role { get; set; } = null!;
+
+    public bool IsDeactivated { get; set; }
     
     public ICollection<UserRefresh> UserRefreshes { get; } = new List<UserRefresh>();
 }

--- a/PatientAnalytics/PatientAnalytics.csproj
+++ b/PatientAnalytics/PatientAnalytics.csproj
@@ -64,15 +64,15 @@
 
     <ItemGroup>
       <EmbeddedResource Update="Blazor\Localization\Localized.resx">
-        <Generator>ResXFileCodeGenerator</Generator>
+        <Generator>PublicResXFileCodeGenerator</Generator>
         <LastGenOutput>Localized.Designer.cs</LastGenOutput>
       </EmbeddedResource>
       <EmbeddedResource Update="Blazor\Localization\Localized.de.resx">
-        <Generator>ResXFileCodeGenerator</Generator>
+        <Generator>PublicResXFileCodeGenerator</Generator>
         <LastGenOutput>Localized.de.Designer.cs</LastGenOutput>
       </EmbeddedResource>
       <EmbeddedResource Update="Blazor\Localization\Localized.zh.resx">
-        <Generator>ResXFileCodeGenerator</Generator>
+        <Generator>PublicResXFileCodeGenerator</Generator>
         <LastGenOutput>Localized.zh.Designer.cs</LastGenOutput>
       </EmbeddedResource>
       <EmbeddedResource Update="Utils\Localization\ApiResponseLocalized.resx">
@@ -83,6 +83,10 @@
         <Generator>PublicResXFileCodeGenerator</Generator>
         <LastGenOutput>ApiResponseLocalized.de.Designer.cs</LastGenOutput>
       </EmbeddedResource>
+        <EmbeddedResource Update="Utils\Localization\ApiResponseLocalized.zh.resx">
+            <Generator>PublicResXFileCodeGenerator</Generator>
+            <LastGenOutput>ApiResponseLocalized.zh.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
     </ItemGroup>
 
 </Project>

--- a/PatientAnalytics/Services/AuthService.cs
+++ b/PatientAnalytics/Services/AuthService.cs
@@ -91,14 +91,22 @@ public class AuthService
 
         if (currentUser == null)
         {
-            throw new HttpStatusCodeException(StatusCodes.Status404NotFound, _localized["AuthError_UserNotFound"]); 
+            throw new HttpStatusCodeException(StatusCodes.Status404NotFound, 
+                _localized["AuthError_UserNotFound"]); 
         }
 
         var passwordHash = Password.HashPassword(loginPayload.Password, _config);
 
         if (currentUser.PasswordHash != passwordHash) 
         { 
-            throw new HttpStatusCodeException(StatusCodes.Status401Unauthorized, _localized["AuthError_WrongPassword"]); 
+            throw new HttpStatusCodeException(StatusCodes.Status401Unauthorized, 
+                _localized["AuthError_WrongPassword"]); 
+        }
+
+        if (currentUser.IsDeactivated)
+        {
+            throw new HttpStatusCodeException(StatusCodes.Status403Forbidden,
+                _localized["AuthError_UserIsDeactivated"]);
         }
         
         return currentUser;

--- a/PatientAnalytics/Services/AuthenticationDataMemoryStorage.cs
+++ b/PatientAnalytics/Services/AuthenticationDataMemoryStorage.cs
@@ -1,5 +1,4 @@
 using System.Security.Claims;
-using PatientAnalytics.Services;
 
 namespace PatientAnalytics.Services;
 

--- a/PatientAnalytics/Services/JwtService.cs
+++ b/PatientAnalytics/Services/JwtService.cs
@@ -88,7 +88,13 @@ public class JwtService
         ValidateToken(token, out var claimsPrincipal);
 
         GetUserFromDatabase(claimsPrincipal, out var user);
-
+        
+        if (user.IsDeactivated)
+        {
+            throw new HttpStatusCodeException(StatusCodes.Status403Forbidden,
+                _localized["AuthError_UserIsDeactivated"]);
+        }
+        
         return user;
     }
 
@@ -97,6 +103,12 @@ public class JwtService
         GetPrincipalFromExpiredToken(token, out var claimsPrincipal);
         
         GetUserFromDatabase(claimsPrincipal, out var user);
+
+        if (user.IsDeactivated)
+        {
+            throw new HttpStatusCodeException(StatusCodes.Status403Forbidden,
+                _localized["AuthError_UserIsDeactivated"]);
+        }
 
         var refreshTokenHash = Password.HashPassword(refreshToken, _config);
         

--- a/PatientAnalytics/Services/PatientAnalyticsUserService.cs
+++ b/PatientAnalytics/Services/PatientAnalyticsUserService.cs
@@ -32,6 +32,7 @@ public class PatientAnalyticsUserService
             
             try
             {
+                // TODO: Check if is deactivated
                 _authenticationDataMemoryStorage.UpdateClaimsPrincipal(_jwtService.DecodeJwt(result.Value));
             }
             catch (HttpStatusCodeException exception)

--- a/PatientAnalytics/Services/PatientService.cs
+++ b/PatientAnalytics/Services/PatientService.cs
@@ -185,7 +185,7 @@ public class PatientService
 
         if (user.Role != "Doctor")
         {
-            throw new HttpStatusCodeException(StatusCodes.Status401Unauthorized,
+            throw new HttpStatusCodeException(StatusCodes.Status403Forbidden,
                 _localized["AuthError_Unauthorized"]);
         }
 

--- a/PatientAnalytics/Services/UserService.cs
+++ b/PatientAnalytics/Services/UserService.cs
@@ -42,6 +42,19 @@ public class UserService
         
         return _context.Users.Where(u => u.Role == "SuperAdmin").ToList();
     }
+
+    public async Task<User> EditUserAccountInfo(string token, int userId, UserAccountInfoPayload payload)
+    {
+        var user = GetUserById(token, userId);
+        
+        user.UpdateAccountInfo(payload);
+
+        _context.Users.Update(user);
+
+        await _context.SaveChangesAsync();
+
+        return user;
+    }
     
     public async Task<IActionResult> DeactivateUser(string token, int userId)
     {

--- a/PatientAnalytics/Services/UserService.cs
+++ b/PatientAnalytics/Services/UserService.cs
@@ -2,27 +2,22 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using PatientAnalytics.Middleware;
 using PatientAnalytics.Models;
-using PatientAnalytics.Models.Auth;
-using PatientAnalytics.Utils;
 using PatientAnalytics.Utils.Localization;
 
 namespace PatientAnalytics.Services;
 
 public class UserService
 {
-    private readonly IConfiguration _config;
     private readonly Context _context;
     private readonly JwtService _jwtService;
     private readonly IStringLocalizer<ApiResponseLocalized> _localized;
 
     public UserService(
-        [FromServices] Context context, 
-        IConfiguration config, 
+        [FromServices] Context context,
         JwtService jwtService,
         IStringLocalizer<ApiResponseLocalized> localized)
     {
         _context = context;
-        _config = config;
         _jwtService = jwtService;
         _localized = localized;
     }
@@ -47,6 +42,64 @@ public class UserService
         
         return _context.Users.Where(u => u.Role == "SuperAdmin").ToList();
     }
+    
+    public async Task<IActionResult> DeactivateUser(string token, int userId)
+    {
+        var user = GetUserById(token, userId);
+
+        if (user.IsDeactivated)
+        {
+            throw new HttpStatusCodeException(StatusCodes.Status409Conflict,
+                string.Format(_localized["UserError_AlreadyDeactivated"], userId));
+        }
+        
+        user.Deactivate();
+
+        _context.Users.Update(user);
+
+        await _context.SaveChangesAsync();
+
+        return new NoContentResult();
+    }
+
+    public async Task<IActionResult> ActivateUser(string token, int userId)
+    {
+        var user = GetUserById(token, userId);
+        
+        if (!user.IsDeactivated)
+        {
+            throw new HttpStatusCodeException(StatusCodes.Status409Conflict,
+                string.Format(_localized["UserError_AlreadyActivated"], userId));
+        }
+        
+        user.Activate();
+
+        _context.Users.Update(user);
+
+        await _context.SaveChangesAsync();
+
+        return new NoContentResult();
+    }
+
+    private User GetUserById(string token, int userId)
+    {
+        ValidateIsAdmin(token, out _);
+        
+        var user = _context.Users.FirstOrDefault(u => u.Id == userId);
+
+        if (user is null)
+        {
+            throw new HttpStatusCodeException(StatusCodes.Status404NotFound,
+                string.Format(_localized["AuthError_DecodeJwt_UserNotFound"], userId));
+        }
+
+        if (user.Role == "SuperAdmin")
+        {
+            ValidateIsSuperAdmin(token, out _);
+        }
+
+        return user;
+    }
 
     private void ValidateIsAdmin(string token, out User verifiedUser)
     {
@@ -54,7 +107,7 @@ public class UserService
 
         if (user.Role != "SuperAdmin" && user.Role != "Admin")
         {
-            throw new HttpStatusCodeException(StatusCodes.Status401Unauthorized, 
+            throw new HttpStatusCodeException(StatusCodes.Status403Forbidden, 
                 _localized["AuthError_Unauthorized"]);
         }
 
@@ -67,8 +120,8 @@ public class UserService
 
         if (user.Role != "SuperAdmin")
         {
-            throw new HttpStatusCodeException(StatusCodes.Status401Unauthorized, 
-                _localized["AuthError_Unauthorized"]);
+            throw new HttpStatusCodeException(StatusCodes.Status403Forbidden, 
+                _localized["AuthError_Unauthorized_SuperAdmin"]);
         }
 
         verifiedUser = user;

--- a/PatientAnalytics/Services/UserService.cs
+++ b/PatientAnalytics/Services/UserService.cs
@@ -109,7 +109,7 @@ public class UserService
         }
     }
 
-    private User GetUserById(string token, int userId)
+    public User GetUserById(string token, int userId)
     {
         ValidateIsAdmin(token, out _);
         

--- a/PatientAnalytics/Services/UserService.cs
+++ b/PatientAnalytics/Services/UserService.cs
@@ -27,28 +27,6 @@ public class UserService
         _localized = localized;
     }
 
-    public async Task<(User, string)> CreateInitialSuperAdmin()
-    {
-        var payload = new RegistrationPayload
-        {
-            DateOfBirth = DateTime.Parse("1990-02-17T06:10:35.950Z"),
-            Gender = "Male",
-            Email = "superadmin@patient-analytics.co.uk",
-            Username = "superadmin",
-            Password = Password.GeneratePassword()
-        };
-        
-        var passwordHash = Password.HashPassword(payload.Password, _config);
-        
-        var user = User.CreateUser(passwordHash, payload, "SuperAdmin");
-        
-        _context.Users.Add(user);
-
-        await _context.SaveChangesAsync();
-        
-        return (user, payload.Password);
-    }
-
     public List<User> GetDoctors(string token)
     {
         ValidateIsAdmin(token, out _);

--- a/PatientAnalytics/Services/UserService.cs
+++ b/PatientAnalytics/Services/UserService.cs
@@ -42,6 +42,26 @@ public class UserService
         
         return _context.Users.Where(u => u.Role == "SuperAdmin").ToList();
     }
+    
+    public User GetUserById(string token, int userId)
+    {
+        ValidateIsAdmin(token, out _);
+        
+        var user = _context.Users.FirstOrDefault(u => u.Id == userId);
+
+        if (user is null)
+        {
+            throw new HttpStatusCodeException(StatusCodes.Status404NotFound,
+                string.Format(_localized["AuthError_DecodeJwt_UserNotFound"], userId));
+        }
+
+        if (user.Role == "SuperAdmin")
+        {
+            ValidateIsSuperAdmin(token, out _);
+        }
+
+        return user;
+    }
 
     public async Task<User> EditUserAccountInfo(string token, int userId, UserAccountInfoPayload payload)
     {
@@ -107,26 +127,6 @@ public class UserService
             throw new HttpStatusCodeException(StatusCodes.Status400BadRequest,
                 _localized["UserError_RequesterConflict"]);
         }
-    }
-
-    public User GetUserById(string token, int userId)
-    {
-        ValidateIsAdmin(token, out _);
-        
-        var user = _context.Users.FirstOrDefault(u => u.Id == userId);
-
-        if (user is null)
-        {
-            throw new HttpStatusCodeException(StatusCodes.Status404NotFound,
-                string.Format(_localized["AuthError_DecodeJwt_UserNotFound"], userId));
-        }
-
-        if (user.Role == "SuperAdmin")
-        {
-            ValidateIsSuperAdmin(token, out _);
-        }
-
-        return user;
     }
 
     private void ValidateIsAdmin(string token, out User verifiedUser)

--- a/PatientAnalytics/Services/UserService.cs
+++ b/PatientAnalytics/Services/UserService.cs
@@ -60,6 +60,8 @@ public class UserService
     {
         var user = GetUserById(token, userId);
 
+        UserIsNotRequester(token, user);
+        
         if (user.IsDeactivated)
         {
             throw new HttpStatusCodeException(StatusCodes.Status409Conflict,
@@ -78,6 +80,8 @@ public class UserService
     public async Task<IActionResult> ActivateUser(string token, int userId)
     {
         var user = GetUserById(token, userId);
+
+        UserIsNotRequester(token, user);
         
         if (!user.IsDeactivated)
         {
@@ -92,6 +96,17 @@ public class UserService
         await _context.SaveChangesAsync();
 
         return new NoContentResult();
+    }
+
+    private void UserIsNotRequester(string token, User user)
+    {
+        var requester = _jwtService.GetUserWithJwt(token);
+
+        if (requester.Id == user.Id)
+        {
+            throw new HttpStatusCodeException(StatusCodes.Status400BadRequest,
+                _localized["UserError_RequesterConflict"]);
+        }
     }
 
     private User GetUserById(string token, int userId)

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.Designer.cs
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.Designer.cs
@@ -153,6 +153,12 @@ namespace PatientAnalytics.Utils.Localization {
             }
         }
         
+        public static string UserError_RequesterConflict {
+            get {
+                return ResourceManager.GetString("UserError_RequesterConflict", resourceCulture);
+            }
+        }
+        
         public static string PatientError_NotFound {
             get {
                 return ResourceManager.GetString("PatientError_NotFound", resourceCulture);

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.Designer.cs
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.Designer.cs
@@ -99,6 +99,12 @@ namespace PatientAnalytics.Utils.Localization {
             }
         }
         
+        public static string AuthError_UserIsDeactivated {
+            get {
+                return ResourceManager.GetString("AuthError_UserIsDeactivated", resourceCulture);
+            }
+        }
+        
         public static string AuthError_WeakPassword_IsHashLeaked {
             get {
                 return ResourceManager.GetString("AuthError_WeakPassword_IsHashLeaked", resourceCulture);

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.Designer.cs
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.Designer.cs
@@ -141,6 +141,18 @@ namespace PatientAnalytics.Utils.Localization {
             }
         }
         
+        public static string UserError_AlreadyActivated {
+            get {
+                return ResourceManager.GetString("UserError_AlreadyActivated", resourceCulture);
+            }
+        }
+        
+        public static string UserError_AlreadyDeactivated {
+            get {
+                return ResourceManager.GetString("UserError_AlreadyDeactivated", resourceCulture);
+            }
+        }
+        
         public static string PatientError_NotFound {
             get {
                 return ResourceManager.GetString("PatientError_NotFound", resourceCulture);

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.Designer.cs
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.Designer.cs
@@ -153,6 +153,12 @@ namespace PatientAnalytics.Utils.Localization {
             }
         }
         
+        public static string UserError_RequesterConflict {
+            get {
+                return ResourceManager.GetString("UserError_RequesterConflict", resourceCulture);
+            }
+        }
+        
         public static string PatientError_NotFound {
             get {
                 return ResourceManager.GetString("PatientError_NotFound", resourceCulture);

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.Designer.cs
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.Designer.cs
@@ -99,6 +99,12 @@ namespace PatientAnalytics.Utils.Localization {
             }
         }
         
+        public static string AuthError_UserIsDeactivated {
+            get {
+                return ResourceManager.GetString("AuthError_UserIsDeactivated", resourceCulture);
+            }
+        }
+        
         public static string AuthError_WeakPassword_IsHashLeaked {
             get {
                 return ResourceManager.GetString("AuthError_WeakPassword_IsHashLeaked", resourceCulture);

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.Designer.cs
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.Designer.cs
@@ -141,6 +141,18 @@ namespace PatientAnalytics.Utils.Localization {
             }
         }
         
+        public static string UserError_AlreadyActivated {
+            get {
+                return ResourceManager.GetString("UserError_AlreadyActivated", resourceCulture);
+            }
+        }
+        
+        public static string UserError_AlreadyDeactivated {
+            get {
+                return ResourceManager.GetString("UserError_AlreadyDeactivated", resourceCulture);
+            }
+        }
+        
         public static string PatientError_NotFound {
             get {
                 return ResourceManager.GetString("PatientError_NotFound", resourceCulture);

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.resx
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.resx
@@ -45,6 +45,9 @@
     <data name="AuthError_WrongPassword" xml:space="preserve">
         <value>Falsches Passwort</value>
     </data>
+    <data name="AuthError_UserIsDeactivated" xml:space="preserve">
+        <value>Der Benutzer ist deaktiviert. Bitte wenden Sie sich für Unterstützung an Ihren Administrator.</value>
+    </data>
     <data name="AuthError_WeakPassword_IsHashLeaked" xml:space="preserve">
         <value>Schwaches Passwort. Dieses Passwort wurde schon einmal durchgesickert. Wählen Sie ein anderes Passwort.</value>
     </data>

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.resx
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.resx
@@ -72,6 +72,9 @@
     <data name="UserError_AlreadyDeactivated" xml:space="preserve">
         <value>Benutzer mit ID: 1 ist bereits deaktiviert</value>
     </data>
+    <data name="UserError_RequesterConflict" xml:space="preserve">
+        <value>Die Anfrage muss von einem anderen Administrator bearbeitet werden.</value>
+    </data>
     <data name="PatientError_NotFound" xml:space="preserve">
         <value>Patient mit ID: {0} konnte nicht gefunden werden</value>
     </data>

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.resx
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.de.resx
@@ -66,6 +66,12 @@
     <data name="AuthError_DecodeJwt_Expired" xml:space="preserve">
         <value>Token ist abgelaufen. Bitte erneut anmelden.</value>
     </data>
+    <data name="UserError_AlreadyActivated" xml:space="preserve">
+        <value>Benutzer mit ID: 1 ist bereits aktiviert</value>
+    </data>
+    <data name="UserError_AlreadyDeactivated" xml:space="preserve">
+        <value>Benutzer mit ID: 1 ist bereits deaktiviert</value>
+    </data>
     <data name="PatientError_NotFound" xml:space="preserve">
         <value>Patient mit ID: {0} konnte nicht gefunden werden</value>
     </data>

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.resx
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.resx
@@ -72,6 +72,9 @@
     <data name="UserError_AlreadyDeactivated" xml:space="preserve">
         <value>User with id: {0} is already deactivated</value>
     </data>
+    <data name="UserError_RequesterConflict" xml:space="preserve">
+        <value>Request must be processed by another admin</value>
+    </data>
     <data name="PatientError_NotFound" xml:space="preserve">
         <value>Unable to locate patient with id: {0}</value>
     </data>

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.resx
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.resx
@@ -66,6 +66,12 @@
     <data name="AuthError_DecodeJwt_Expired" xml:space="preserve">
         <value>Token is expired. Please login again.</value>
     </data>
+    <data name="UserError_AlreadyActivated" xml:space="preserve">
+        <value>User with id: {0} is already activated</value>
+    </data>
+    <data name="UserError_AlreadyDeactivated" xml:space="preserve">
+        <value>User with id: {0} is already deactivated</value>
+    </data>
     <data name="PatientError_NotFound" xml:space="preserve">
         <value>Unable to locate patient with id: {0}</value>
     </data>

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.resx
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.resx
@@ -45,6 +45,9 @@
     <data name="AuthError_WrongPassword" xml:space="preserve">
         <value>Wrong Password</value>
     </data>
+    <data name="AuthError_UserIsDeactivated" xml:space="preserve">
+        <value>User is deactivated. Please contact your admin for support.</value>
+    </data>
     <data name="AuthError_WeakPassword_IsHashLeaked" xml:space="preserve">
         <value>Weak password. This password has been leaked before. Choose a different password.</value>
     </data>

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.zh.resx
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.zh.resx
@@ -45,6 +45,9 @@
     <data name="AuthError_WrongPassword" xml:space="preserve">
         <value>密碼錯誤</value>
     </data>
+    <data name="AuthError_UserIsDeactivated" xml:space="preserve">
+        <value>用戶已被停用。請聯絡您的管理員尋求支援。</value>
+    </data>
     <data name="AuthError_WeakPassword_IsHashLeaked" xml:space="preserve">
         <value>密碼強度低。該密碼之前曾被洩漏過。請嘗試另一組密碼。</value>
     </data>

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.zh.resx
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.zh.resx
@@ -72,6 +72,9 @@
     <data name="UserError_AlreadyDeactivated" xml:space="preserve">
         <value>ID 為 {0} 的使用者已停用</value>
     </data>
+    <data name="UserError_RequesterConflict" xml:space="preserve">
+        <value>請求必須由其他管理員處理</value>
+    </data>
     <data name="PatientError_NotFound" xml:space="preserve">
         <value>無法找到 ID 為 {0} 的患者</value>
     </data>

--- a/PatientAnalytics/Utils/Localization/ApiResponseLocalized.zh.resx
+++ b/PatientAnalytics/Utils/Localization/ApiResponseLocalized.zh.resx
@@ -66,6 +66,12 @@
     <data name="AuthError_DecodeJwt_Expired" xml:space="preserve">
         <value>加密代幣已過期。請重新登入。</value>
     </data>
+    <data name="UserError_AlreadyActivated" xml:space="preserve">
+        <value>ID 為 {0} 的用戶已啟動</value>
+    </data>
+    <data name="UserError_AlreadyDeactivated" xml:space="preserve">
+        <value>ID 為 {0} 的使用者已停用</value>
+    </data>
     <data name="PatientError_NotFound" xml:space="preserve">
         <value>無法找到 ID 為 {0} 的患者</value>
     </data>


### PR DESCRIPTION
- Initial implementation of IsDeactivated param in User model, database migration and check implementation on login, get user jwt and expired jwt
- Implementation of activate and deactivate user
- Edit user account information implementation
- Disable ability for user to activate / deactivate themselves
- User Management Page initial implementation, Modal management initial implementation and testing UserService GetUserById
- User activation / deactivation blazor functionality implementation
- PersonalDetailsDisplay component implementation
- Edit User Form Modal implementation and usage
- Update Localization for user pages
- Updated gitignore to omit DotSettings
- BlazorAlertController implementation and usage
- Renamed Modal to Alert
- ConfirmationModal updated props usage and BlazorAlertController implementation to all componenets that use ConfirmationModal
- Updated Retrive and Edit User APIs
- Minor Alert file update
- Blazor global import updates